### PR TITLE
RWA-78 Working day service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,8 @@ def versions = [
   reformLogging   : '5.1.5',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
-  serenity        : '2.2.12'
+  serenity        : '2.2.12',
+  camunda         : '7.13.0'
 ]
 
 ext.libraries = [
@@ -236,6 +237,8 @@ dependencies {
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.4.RELEASE'
 
+  compile group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '1.3.1'
+
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'
@@ -252,7 +255,7 @@ dependencies {
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
   //for testing Camunda config will move out of this project
-  integrationTestImplementation group: 'org.camunda.bpm.dmn', name: 'camunda-engine-dmn', version: '7.13.0'
+  integrationTestImplementation group: 'org.camunda.bpm.dmn', name: 'camunda-engine-dmn', version: "${versions.camunda}"
   integrationTestImplementation group: 'org.camunda.bpm.assert', name: 'camunda-bpm-assert', version: '7.0.0'
   integrationTestImplementation group: 'org.camunda.bpm', name: 'camunda-engine', version: '7.13.0'
   integrationTestImplementation group: 'com.h2database', name: 'h2', version: '1.4.200'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/CreateTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/CreateTaskTest.java
@@ -5,18 +5,24 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequest;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static net.serenitybdd.rest.SerenityRest.given;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestBuilder.aCreateTaskRequest;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.appealSubmittedCreateTaskRequest;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.requestRespondentEvidenceTaskRequest;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.unmappedCreateTaskRequest;
+import static uk.gov.hmcts.reform.waworkflowapi.api.TransitionBuilder.aTransition;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.AvoidDuplicateLiterals"})
 public class CreateTaskTest {
 
     private final String testUrl = System.getenv("TEST_URL") == null ? "http://localhost:8099" :  System.getenv("TEST_URL");
@@ -35,7 +41,7 @@ public class CreateTaskTest {
             .contentType(APPLICATION_JSON_VALUE)
             .body(appealSubmittedCreateTaskRequest(caseId)).log().body()
             .baseUri(testUrl)
-            .basePath("tasks")
+            .basePath("/tasks")
             .when()
             .post()
             .then()
@@ -73,7 +79,7 @@ public class CreateTaskTest {
             .contentType(APPLICATION_JSON_VALUE)
             .body(requestRespondentEvidenceTaskRequest(caseId)).log().body()
             .baseUri(testUrl)
-            .basePath("tasks")
+            .basePath("/tasks")
             .when()
             .post()
             .then()
@@ -111,7 +117,7 @@ public class CreateTaskTest {
             .contentType(APPLICATION_JSON_VALUE)
             .body(unmappedCreateTaskRequest(caseId)).log().body()
             .baseUri(testUrl)
-            .basePath("tasks")
+            .basePath("/tasks")
             .when()
             .post()
             .then()
@@ -126,5 +132,49 @@ public class CreateTaskTest {
             .get()
             .then()
             .body("size()", is(0));
+    }
+
+    @Test
+    public void transitionCreateOverdueTask() {
+        CreateTaskRequest createTaskRequest = aCreateTaskRequest()
+            .withCaseId(caseId)
+            .withTransition(
+                aTransition()
+                    .withPreState("appealSubmitted")
+                    .withEventId("requestRespondentEvidence")
+                    .withPostState("awaitingRespondentEvidence")
+                    .build()
+            )
+            .withDueDate(ZonedDateTime.now())
+            .build();
+        given()
+            .relaxedHTTPSValidation()
+            .contentType(APPLICATION_JSON_VALUE)
+            .body(createTaskRequest).log().body()
+            .baseUri(testUrl)
+            .basePath("/tasks")
+            .when()
+            .post()
+            .then()
+            .statusCode(HttpStatus.CREATED_201);
+
+        await().ignoreException(AssertionError.class).pollInterval(1, SECONDS).atMost(60, SECONDS).until(
+            () -> {
+                given()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .baseUri(camundaUrl)
+                    .basePath("/task")
+                    .param("processVariables", "ccdId_eq_" + caseId)
+                    .when()
+                    .get()
+                    .prettyPeek()
+                    .then()
+                    .body("size()", is(2))
+                    .body("[0].name", is("Process Task"))
+                    .body("[1].name", is("Process overdue task"));
+
+                return true;
+            }
+        );
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/CreateTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/CreateTaskTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.waworkflowapi.features.something;
+package uk.gov.hmcts.reform.waworkflowapi.features;
 
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
 import org.eclipse.jetty.http.HttpStatus;
@@ -12,7 +12,7 @@ import static net.serenitybdd.rest.SerenityRest.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.appealSubmittedCreateTaskRequest;
-import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.appealSubmittedCreateTaskRequestWithDueDate;
+import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.requestRespondentEvidenceTaskRequest;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.unmappedCreateTaskRequest;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
@@ -71,7 +71,7 @@ public class CreateTaskTest {
         given()
             .relaxedHTTPSValidation()
             .contentType(APPLICATION_JSON_VALUE)
-            .body(appealSubmittedCreateTaskRequestWithDueDate(caseId)).log().body()
+            .body(requestRespondentEvidenceTaskRequest(caseId)).log().body()
             .baseUri(testUrl)
             .basePath("tasks")
             .when()
@@ -101,7 +101,7 @@ public class CreateTaskTest {
             .get()
             .prettyPeek()
             .then()
-            .body("[0].groupId", is("TCW"));
+            .body("[0].groupId", is("external"));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
@@ -9,38 +9,48 @@ import org.junit.Test;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.time.ZonedDateTime.now;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.util.Collections.singletonMap;
+import static java.util.Date.from;
 import static java.util.Map.of;
 import static org.apache.commons.lang3.time.DateUtils.isSameDay;
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.assertThat;
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.complete;
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.task;
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
+import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTask;
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.hmcts.reform.waworkflowapi.ProcessEngineBuilder.getProcessEngine;
 
-@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.UseConcurrentHashMap" })
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.UseConcurrentHashMap"})
 public class CamundaCreateTaskTest {
 
     public static final String PROCESS_TASK = "processTask";
     public static final String PROCESS_OVERDUE_TASK = "processOverdueTask";
     private static final String EXPECTED_GROUP = "TCW";
-    private static final ZonedDateTime DUE_DATE = ZonedDateTime.now().plusDays(7);
-    private static final String DUE_DATE_STRING = DUE_DATE.format(DateTimeFormatter.ISO_INSTANT);
-    public static final Date DUE_DATE_DATE = Date.from(DUE_DATE.toInstant());
+    private static final ZonedDateTime DUE_DATE = now().plusDays(7);
+    private static final String DUE_DATE_STRING = DUE_DATE.format(ISO_INSTANT);
+    public static final Date DUE_DATE_DATE = from(DUE_DATE.toInstant());
+    public static final String CALCULATE_DUE_DATE_TASK = "calculateDueDate";
 
     @Rule
     public ProcessEngineRule processEngineRule = new ProcessEngineRule(getProcessEngine());
 
     @Test
-    @Deployment(resources = { "create_task.bpmn" })
+    @Deployment(resources = {"create_task.bpmn"})
     public void createsAndCompletesATaskWithADueDate() {
-        ProcessInstance processInstance = startCreateTaskProcess(of("group", EXPECTED_GROUP, "dueDate", DUE_DATE_STRING));
+        ProcessInstance processInstance = startCreateTaskProcess(of(
+            "group",
+            EXPECTED_GROUP,
+            "dueDate",
+            DUE_DATE_STRING
+        ));
 
         assertThat(processInstance).isStarted()
             .task()
@@ -56,7 +66,7 @@ public class CamundaCreateTaskTest {
     }
 
     @Test
-    @Deployment(resources = { "create_task.bpmn" })
+    @Deployment(resources = {"create_task.bpmn"})
     public void createsAndCompletesATaskWithoutADueDate() {
         Map<String, Object> processVariables = new HashMap<>();
         processVariables.put("group", EXPECTED_GROUP);
@@ -70,17 +80,23 @@ public class CamundaCreateTaskTest {
             .isNotAssigned();
 
         Date dueDate = task().getDueDate();
-        Date expectedDueDate = Date.from(LocalDate.now().plusDays(2).atStartOfDay().toInstant(ZoneOffset.UTC));
-        assertTrue("Expected [" + dueDate + "] to be on [" + expectedDueDate + "]", isSameDay(dueDate, expectedDueDate));
+        Date expectedDueDate = from(LocalDate.now().plusDays(2).atStartOfDay().toInstant(ZoneOffset.UTC));
+        assertTrue(
+            "Expected [" + dueDate + "] to be on [" + expectedDueDate + "]",
+            isSameDay(dueDate, expectedDueDate)
+        );
 
         Date jobDueDate = job().getDuedate();
-        assertTrue("Expected [" + jobDueDate + "] to be on [" + expectedDueDate + "]", isSameDay(jobDueDate, expectedDueDate));
+        assertTrue(
+            "Expected [" + jobDueDate + "] to be on [" + expectedDueDate + "]",
+            isSameDay(jobDueDate, expectedDueDate)
+        );
         complete(task(PROCESS_TASK));
         assertThat(processInstance).isEnded();
     }
 
     @Test
-    @Deployment(resources = { "create_task.bpmn", "getOverdueTask.dmn" })
+    @Deployment(resources = {"create_task.bpmn", "getOverdueTask.dmn"})
     public void overdueAndOverdueTaskIsCreated() {
         ProcessInstance processInstance = startCreateTaskProcess(
             of("taskId", "provideRespondentEvidence", "group", EXPECTED_GROUP, "dueDate", DUE_DATE_STRING)
@@ -90,10 +106,19 @@ public class CamundaCreateTaskTest {
             .task()
             .hasDefinitionKey(PROCESS_TASK)
             .isNotAssigned();
+
         execute(job());
         assertThat(processInstance).isWaitingAt(PROCESS_TASK);
+        assertThat(processInstance).isWaitingAt(CALCULATE_DUE_DATE_TASK);
+
+        ZonedDateTime overdueTaskDueDate = now();
+        complete(
+            externalTask(CALCULATE_DUE_DATE_TASK),
+            singletonMap("overdueTaskDueDate", overdueTaskDueDate.format(ISO_INSTANT))
+        );
         assertThat(processInstance).isWaitingAt(PROCESS_OVERDUE_TASK);
         assertThat(processInstance).task(PROCESS_OVERDUE_TASK).hasCandidateGroup("TCW");
+        assertThat(processInstance).task(PROCESS_OVERDUE_TASK).hasDueDate(from(overdueTaskDueDate.toInstant()));
 
         complete(task(PROCESS_OVERDUE_TASK));
         assertThat(processInstance).isWaitingAt(PROCESS_TASK);
@@ -105,7 +130,7 @@ public class CamundaCreateTaskTest {
     }
 
     @Test
-    @Deployment(resources = { "create_task.bpmn", "getOverdueTask.dmn" })
+    @Deployment(resources = {"create_task.bpmn", "getOverdueTask.dmn"})
     public void overdueAndOverdueTaskIsNotCreated() {
         ProcessInstance processInstance = startCreateTaskProcess(
             of("taskId", "anotherTask", "group", EXPECTED_GROUP, "dueDate", DUE_DATE_STRING)
@@ -126,6 +151,6 @@ public class CamundaCreateTaskTest {
 
     private ProcessInstance startCreateTaskProcess(Map<String, Object> processVariables) {
         return processEngineRule.getRuntimeService()
-                .startProcessInstanceByMessage("createTaskMessage", processVariables);
+            .startProcessInstanceByMessage("createTaskMessage", processVariables);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
@@ -31,7 +31,7 @@ public class CamundaCreateTaskTest {
     public static final String PROCESS_OVERDUE_TASK = "processOverdueTask";
     private static final String EXPECTED_GROUP = "TCW";
     private static final ZonedDateTime DUE_DATE = ZonedDateTime.now().plusDays(7);
-    private static final String DUE_DATE_STRING = DUE_DATE.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    private static final String DUE_DATE_STRING = DUE_DATE.format(DateTimeFormatter.ISO_INSTANT);
     public static final Date DUE_DATE_DATE = Date.from(DUE_DATE.toInstant());
 
     @Rule

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetOverdueTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetOverdueTaskTest.java
@@ -34,20 +34,22 @@ class CamundaGetOverdueTaskTest {
     @DisplayName("Get overdue task")
     @ParameterizedTest(name = "\"{0}\" should go to \"{1}\"")
     @CsvSource({
-        "provideRespondentEvidence, followUpOverdueRespondentEvidence, TCW",
-        "provideCaseBuilding, followUpOverdueCaseBuilding, TCW",
-        "provideReasonsForAppeal, followUpOverdueReasonsForAppeal, TCW",
-        "provideClarifyingAnswers, followUpOverdueClarifyingAnswers, TCW",
-        "provideCmaRequirements, followUpOverdueCmaRequirements, TCW",
-        "provideRespondentReview, followUpOverdueRespondentReview, TCW",
-        "provideHearingRequirements, followUpOverdueHearingRequirements, TCW"
+        "provideRespondentEvidence, followUpOverdueRespondentEvidence, TCW, 2",
+        "provideCaseBuilding, followUpOverdueCaseBuilding, TCW, 2",
+        "provideReasonsForAppeal, followUpOverdueReasonsForAppeal, TCW, 2",
+        "provideClarifyingAnswers, followUpOverdueClarifyingAnswers, TCW, 2",
+        "provideCmaRequirements, followUpOverdueCmaRequirements, TCW, 2",
+        "provideRespondentReview, followUpOverdueRespondentReview, TCW, 2",
+        "provideHearingRequirements, followUpOverdueHearingRequirements, TCW, 2"
     })
-    void shouldGetOverdueTaskIdTest(String taskId, String overdueTaskId) {
+    void shouldGetOverdueTaskIdTest(String taskId, String overdueTaskId, String group, Integer workingDaysAllowed) {
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmn(taskId);
 
         DmnDecisionRuleResult singleResult = dmnDecisionTableResult.getSingleResult();
 
         assertThat(singleResult.getEntry("taskId"), is(overdueTaskId));
+        assertThat(singleResult.getEntry("group"), is(group));
+        assertThat(singleResult.getEntry("workingDaysAllowed"), is(workingDaysAllowed));
     }
 
     @DisplayName("transition unmapped")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetTaskTest.java
@@ -34,33 +34,38 @@ class CamundaGetTaskTest {
     @DisplayName("Get task id")
     @ParameterizedTest(name = "\"{0}\" \"{1}\" should go to \"{2}\"")
     @CsvSource({
-        "submitAppeal, anything, processApplication, TCW",
-        "submitTimeExtension, anything, decideOnTimeExtension, TCW",
-        "uploadHomeOfficeBundle, awaitingRespondentEvidence, reviewRespondentEvidence, TCW",
-        "submitCase, caseUnderReview, reviewAppealSkeletonArgument, TCW",
-        "submitReasonsForAppeal, reasonsForAppealSubmitted, reviewReasonsForAppeal, TCW",
-        "submitClarifyingQuestionAnswers, clarifyingQuestionsAnswersSubmitted, reviewClarifyingQuestionsAnswers, TCW",
-        "submitCmaRequirements, cmaRequirementsSubmitted, reviewCmaRequirements, TCW",
-        "listCma, cmaListed, attendCma, TCW",
-        "uploadHomeOfficeAppealResponse, respondentReview, reviewRespondentResponse, TCW",
-        "anything, prepareForHearing, createCaseSummary, TCW",
-        "anything, finalBundling, createHearingBundle, TCW",
-        "anything, preHearing, startDecisionsAndReasonsDocument, TCW",
-        "requestRespondentEvidence, awaitingRespondentEvidence, provideRespondentEvidence, external",
-        "requestCaseBuilding, caseBuilding, provideCaseBuilding, external",
-        "requestReasonsForAppeal, awaitingReasonsForAppeal, provideReasonsForAppeal, external",
-        "sendDirectionWithQuestions, awaitingClarifyingQuestionsAnswers, provideClarifyingAnswers, external",
-        "requestCmaRequirements, awaitingCmaRequirements, provideCmaRequirements, external",
-        "requestRespondentReview, respondentReview, provideRespondentReview, external",
-        "requestHearingRequirements, submitHearingRequirements, provideHearingRequirements, external"
+        "submitAppeal, anything, processApplication, TCW, 2",
+        "submitTimeExtension, anything, decideOnTimeExtension, TCW, 2",
+        "uploadHomeOfficeBundle, awaitingRespondentEvidence, reviewRespondentEvidence, TCW, 2",
+        "submitCase, caseUnderReview, reviewAppealSkeletonArgument, TCW, 2",
+        "submitReasonsForAppeal, reasonsForAppealSubmitted, reviewReasonsForAppeal, TCW, 2",
+        "submitClarifyingQuestionAnswers, clarifyingQuestionsAnswersSubmitted, reviewClarifyingQuestionsAnswers, TCW, 2",
+        "submitCmaRequirements, cmaRequirementsSubmitted, reviewCmaRequirements, TCW, 2",
+        "listCma, cmaListed, attendCma, TCW, 2",
+        "uploadHomeOfficeAppealResponse, respondentReview, reviewRespondentResponse, TCW, 2",
+        "anything, prepareForHearing, createCaseSummary, TCW, 2",
+        "anything, finalBundling, createHearingBundle, TCW, 2",
+        "anything, preHearing, startDecisionsAndReasonsDocument, TCW, 2",
+        "requestRespondentEvidence, awaitingRespondentEvidence, provideRespondentEvidence, external, -1",
+        "requestCaseBuilding, caseBuilding, provideCaseBuilding, external, -1",
+        "requestReasonsForAppeal, awaitingReasonsForAppeal, provideReasonsForAppeal, external, -1",
+        "sendDirectionWithQuestions, awaitingClarifyingQuestionsAnswers, provideClarifyingAnswers, external, -1",
+        "requestCmaRequirements, awaitingCmaRequirements, provideCmaRequirements, external, -1",
+        "requestRespondentReview, respondentReview, provideRespondentReview, external, -1",
+        "requestHearingRequirements, submitHearingRequirements, provideHearingRequirements, external, -1"
     })
-    void shouldGetTaskIdTest(String eventId, String postState, String taskId, String group) {
+    void shouldGetTaskIdTest(String eventId, String postState, String taskId, String group, Integer workingDaysAllowed) {
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmn(eventId, postState);
 
         DmnDecisionRuleResult singleResult = dmnDecisionTableResult.getSingleResult();
 
         assertThat(singleResult.getEntry("taskId"), is(taskId));
         assertThat(singleResult.getEntry("group"), is(group));
+        if (workingDaysAllowed > 0) {
+            assertThat(singleResult.getEntry("workingDaysAllowed"), is(workingDaysAllowed));
+        } else {
+            assertThat(singleResult.containsKey("workingDaysAllowed"), is(false));
+        }
     }
 
     @DisplayName("transition unmapped")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/controllers/CreateTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/controllers/CreateTaskTest.java
@@ -8,16 +8,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.CreateTaskRequest;
+import uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequest;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.DateService;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.DueDateService;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.CamundaClient;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnRequest;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.GetTaskDmnRequest;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.GetTaskDmnResult;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.ProcessVariables;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.SendMessageRequest;
+import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.TaskToCreate;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
+import static java.time.ZonedDateTime.parse;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.any;
@@ -29,12 +34,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.appealSubmittedCreateTaskRequest;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.appealSubmittedCreateTaskRequestWithDueDate;
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreatorObjectMapper.asJsonString;
+import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnIntegerValue;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnStringValue;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.PROCESS_APPLICATION;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "PMD.ExcessiveImports"})
 class CreateTaskTest {
 
     @Autowired
@@ -43,9 +49,17 @@ class CreateTaskTest {
     @MockBean
     private CamundaClient camundaClient;
 
+    @Autowired
+    private DueDateService dueDateService;
+
+    @MockBean DateService dateService;
+
     @DisplayName("Should create task with default due date and 201 response")
     @Test
     void createsTaskForTransitionWithoutDueDate() throws Exception {
+        ZonedDateTime now = ZonedDateTime.now();
+        when(dateService.now()).thenReturn(now);
+
         CreateTaskRequest createTaskRequest = appealSubmittedCreateTaskRequest("1234567890");
         when(camundaClient.getTask(createGetTaskDmnRequest(createTaskRequest)))
             .thenReturn(createGetTaskResponse());
@@ -55,6 +69,11 @@ class CreateTaskTest {
                 .content(asJsonString(createTaskRequest))
         ).andExpect(status().isCreated()).andReturn();
 
+        ZonedDateTime expectedDueDate = dueDateService.calculateDueDate(
+            null,
+            new TaskToCreate(null, null, 5)
+        );
+
         verify(camundaClient).sendMessage(
             new SendMessageRequest(
                 "createTaskMessage",
@@ -62,7 +81,7 @@ class CreateTaskTest {
                     createTaskRequest.getCaseId(),
                     PROCESS_APPLICATION,
                     "TCW",
-                    null
+                    expectedDueDate
                 )
             )
         );
@@ -87,7 +106,7 @@ class CreateTaskTest {
                     createTaskRequest.getCaseId(),
                     PROCESS_APPLICATION,
                     "TCW",
-                    createTaskRequest.getDueDate()
+                    parse(createTaskRequest.getDueDate())
                 )
             )
         );
@@ -118,6 +137,11 @@ class CreateTaskTest {
     }
 
     private List<GetTaskDmnResult> createGetTaskResponse() {
-        return singletonList(new GetTaskDmnResult(dmnStringValue(PROCESS_APPLICATION.getId()), dmnStringValue("TCW")));
+        return singletonList(new GetTaskDmnResult(
+                                 dmnStringValue(PROCESS_APPLICATION.getId()),
+                                 dmnStringValue("TCW"),
+                                 dmnIntegerValue(5)
+                             )
+        );
     }
 }

--- a/src/integrationTest/resources/create_task.bpmn
+++ b/src/integrationTest/resources/create_task.bpmn
@@ -35,32 +35,35 @@
     <bpmn:exclusiveGateway id="Gateway_1okq3ab">
       <bpmn:incoming>Flow_1dygid7</bpmn:incoming>
       <bpmn:outgoing>Flow_0xlwe3k</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0goqofl</bpmn:outgoing>
+      <bpmn:outgoing>Flow_17hz6gt</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:userTask id="processOverdueTask" name="Process overdue task" camunda:candidateGroups="${task.group}">
+    <bpmn:userTask id="processOverdueTask" name="Process overdue task" camunda:candidateGroups="${task.group}" camunda:dueDate="${overdueTaskDueDate}">
       <bpmn:incoming>Flow_0goqofl</bpmn:incoming>
       <bpmn:outgoing>Flow_0sv04ne</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_0goqofl" name="Create overdue task" sourceRef="Gateway_1okq3ab" targetRef="processOverdueTask">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${task != null}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0goqofl" name="Create overdue task" sourceRef="calculateDueDate" targetRef="processOverdueTask" />
     <bpmn:endEvent id="Event_076nh9d" name="Overdue task completed">
       <bpmn:incoming>Flow_0sv04ne</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0sv04ne" sourceRef="processOverdueTask" targetRef="Event_076nh9d" />
+    <bpmn:sequenceFlow id="Flow_17hz6gt" sourceRef="Gateway_1okq3ab" targetRef="calculateDueDate" />
+    <bpmn:serviceTask id="calculateDueDate" name="Calculate Due Date" camunda:type="external" camunda:topic="calculate-due-date">
+      <bpmn:incoming>Flow_17hz6gt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0goqofl</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmn:message id="Message_1pi3bbk" name="createTaskMessage" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="createUserTask">
       <bpmndi:BPMNEdge id="Flow_0sv04ne_di" bpmnElement="Flow_0sv04ne">
-        <di:waypoint x="790" y="420" />
-        <di:waypoint x="842" y="420" />
+        <di:waypoint x="790" y="510" />
+        <di:waypoint x="842" y="510" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0goqofl_di" bpmnElement="Flow_0goqofl">
-        <di:waypoint x="740" y="281" />
-        <di:waypoint x="740" y="380" />
+        <di:waypoint x="740" y="390" />
+        <di:waypoint x="740" y="470" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="717" y="328" width="76" height="27" />
+          <dc:Bounds x="702" y="410" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xlwe3k_di" bpmnElement="Flow_0xlwe3k">
@@ -85,6 +88,10 @@
       <bpmndi:BPMNEdge id="Flow_1ex1957_di" bpmnElement="Flow_1ex1957">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="530" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17hz6gt_di" bpmnElement="Flow_17hz6gt">
+        <di:waypoint x="740" y="281" />
+        <di:waypoint x="740" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1h3qguy_di" bpmnElement="processTask">
         <dc:Bounds x="530" y="77" width="100" height="80" />
@@ -113,13 +120,16 @@
       <bpmndi:BPMNShape id="Gateway_1svqvkp_di" bpmnElement="Gateway_1okq3ab" isMarkerVisible="true">
         <dc:Bounds x="715" y="231" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12w2x1m_di" bpmnElement="calculateDueDate">
+        <dc:Bounds x="690" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00ol99a_di" bpmnElement="processOverdueTask">
-        <dc:Bounds x="690" y="380" width="100" height="80" />
+        <dc:Bounds x="690" y="470" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_076nh9d_di" bpmnElement="Event_076nh9d">
-        <dc:Bounds x="842" y="402" width="36" height="36" />
+        <dc:Bounds x="842" y="492" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="828" y="445" width="66" height="27" />
+          <dc:Bounds x="828" y="535" width="66" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0e220h0_di" bpmnElement="overdueTaskTimer">

--- a/src/integrationTest/resources/getOverdueTask.dmn
+++ b/src/integrationTest/resources/getOverdueTask.dmn
@@ -9,6 +9,7 @@
       </input>
       <output id="Output_1" label="Task Id" name="taskId" typeRef="string" />
       <output id="OutputClause_0l5ezm8" label="Group" name="group" typeRef="string" />
+      <output id="OutputClause_0cc4yuf" label="Working Days Allowed" name="workingDaysAllowed" typeRef="integer" />
       <rule id="DecisionRule_0r5llam">
         <inputEntry id="UnaryTests_08zv4eq">
           <text>"provideRespondentEvidence"</text>
@@ -18,6 +19,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0wln9if">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1f69864">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1cvwlqt">
@@ -30,6 +34,9 @@
         <outputEntry id="LiteralExpression_0n62pfk">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1hf5645">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_06ja87r">
         <inputEntry id="UnaryTests_16370hj">
@@ -40,6 +47,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1oeju8y">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_16qv6sr">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_065z1ps">
@@ -52,6 +62,9 @@
         <outputEntry id="LiteralExpression_17m7v9t">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_0vtn0y2">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_0q22bds">
         <inputEntry id="UnaryTests_0ngobq4">
@@ -62,6 +75,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_153ewk4">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1f75ves">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ynjokj">
@@ -74,6 +90,9 @@
         <outputEntry id="LiteralExpression_01g5vk0">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1vlxrfl">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1cpw47c">
         <inputEntry id="UnaryTests_0mu2lnf">
@@ -84,6 +103,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_07xrbh4">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0bkded4">
+          <text>2</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/integrationTest/resources/getTaskId.dmn
+++ b/src/integrationTest/resources/getTaskId.dmn
@@ -14,6 +14,7 @@
       </input>
       <output id="Output_1" label="Task Id" name="taskId" typeRef="string" />
       <output id="OutputClause_0f63m65" label="Group" name="group" typeRef="string" />
+      <output id="OutputClause_0i6c6c2" label="Working Days Allowed" name="workingDaysAllowed" typeRef="integer" />
       <rule id="DecisionRule_1fenvxm">
         <inputEntry id="UnaryTests_09nq8bu">
           <text>"submitAppeal"</text>
@@ -26,6 +27,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0epp4rf">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1td2bt7">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_046wm6a">
@@ -41,6 +45,9 @@
         <outputEntry id="LiteralExpression_0o3ekx3">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_16urfvv">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_0gm0jgu">
         <inputEntry id="UnaryTests_03i96yg">
@@ -54,6 +61,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0ezi8jw">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_057kfbi">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0wvehb6">
@@ -69,6 +79,9 @@
         <outputEntry id="LiteralExpression_1pbeee3">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1qxex0h">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_12seemc">
         <inputEntry id="UnaryTests_1y0vrr4">
@@ -82,6 +95,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1ey5yzs">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1w4a5dv">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0oelx3m">
@@ -97,6 +113,9 @@
         <outputEntry id="LiteralExpression_1vlo7cs">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1ir1zsl">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1qug6sw">
         <inputEntry id="UnaryTests_1keumr9">
@@ -110,6 +129,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_180gwcu">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hxjfjs">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0odg0q4">
@@ -125,6 +147,9 @@
         <outputEntry id="LiteralExpression_05ydvee">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1umafvm">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1tpr9e2">
         <inputEntry id="UnaryTests_0jppcim">
@@ -138,6 +163,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1tjk1uy">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_11qiura">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_02svucz">
@@ -153,6 +181,9 @@
         <outputEntry id="LiteralExpression_02ocahm">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1m82yii">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1p1dgii">
         <inputEntry id="UnaryTests_1sl3ymc">
@@ -166,6 +197,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1846q2j">
           <text>"TCW"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0ct7jss">
+          <text>2</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0rscfh8">
@@ -181,6 +215,9 @@
         <outputEntry id="LiteralExpression_0e3nnlv">
           <text>"TCW"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_0twp9o1">
+          <text>2</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1sneoct">
         <inputEntry id="UnaryTests_1ws9i8w">
@@ -194,6 +231,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_10iwep1">
           <text>"external"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hs752d">
+          <text></text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1cryksr">
@@ -209,6 +249,9 @@
         <outputEntry id="LiteralExpression_0xikhzp">
           <text>"external"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_16pog0r">
+          <text></text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1puaqjc">
         <inputEntry id="UnaryTests_0e1x2w0">
@@ -222,6 +265,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_1l5fl2v">
           <text>"external"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_166xjyk">
+          <text></text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_18csya4">
@@ -237,6 +283,9 @@
         <outputEntry id="LiteralExpression_0u68a06">
           <text>"external"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1hzaewn">
+          <text></text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_0ilfnvo">
         <inputEntry id="UnaryTests_17nkudc">
@@ -250,6 +299,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_11hjg6x">
           <text>"external"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0krj9ux">
+          <text></text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_170q68k">
@@ -265,6 +317,9 @@
         <outputEntry id="LiteralExpression_1k5wucv">
           <text>"external"</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_0gji1hv">
+          <text></text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_0ft10ad">
         <inputEntry id="UnaryTests_1imhsea">
@@ -278,6 +333,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_14xa26a">
           <text>"external"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1k8sdn1">
+          <text></text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/startworkflow/CreateTaskController.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/startworkflow/CreateTaskController.java
@@ -24,14 +24,18 @@ public class CreateTaskController {
         this.taskService = taskService;
     }
 
-    @PostMapping(path = "/tasks", consumes = { MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(path = "/tasks", consumes = {MediaType.APPLICATION_JSON_VALUE})
     @ApiOperation("Starts the workflow to create a task")
     @ApiResponses({
         @ApiResponse(code = 201, message = "A new task has been created for the transition"),
         @ApiResponse(code = 204, message = "No new task was created for the transition")
     })
     public ResponseEntity createTask(@RequestBody CreateTaskRequest createTaskRequest) {
-        if (taskService.createTask(createTaskRequest.getTransition(), createTaskRequest.getCaseId(), createTaskRequest.getDueDate())) {
+        if (taskService.createTask(
+            createTaskRequest.getTransition(),
+            createTaskRequest.getCaseId(),
+            createTaskRequest.getDueDate()
+        )) {
             return created(null).build();
         } else {
             return noContent().build();

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/startworkflow/CreateTaskRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/startworkflow/CreateTaskRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 public class CreateTaskRequest {
@@ -15,9 +16,9 @@ public class CreateTaskRequest {
     @ApiModelProperty(
         example = "2020-09-05T14:47:01.250542+01:00",
         notes = "Optional due date for the task that will be created")
-    private final String dueDate;
+    private final ZonedDateTime dueDate;
 
-    public CreateTaskRequest(String caseId, Transition transition, String dueDate) {
+    public CreateTaskRequest(String caseId, Transition transition, ZonedDateTime dueDate) {
         this.caseId = caseId;
         this.transition = transition;
         this.dueDate = dueDate;
@@ -31,7 +32,7 @@ public class CreateTaskRequest {
         return transition;
     }
 
-    public String getDueDate() {
+    public ZonedDateTime getDueDate() {
         return dueDate;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DateService.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import java.time.ZonedDateTime;
+
+public interface DateService {
+    ZonedDateTime now();
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateExternalService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateExternalService.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.camunda.bpm.client.ExternalTaskClient;
+import org.camunda.bpm.client.task.ExternalTask;
+import org.camunda.bpm.client.task.ExternalTaskService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static java.util.Collections.singletonMap;
+
+@SuppressWarnings({"PMD.UseUnderscoresInNumericLiterals"})
+@Component
+public class DueDateExternalService {
+    private static final Logger LOGGER = Logger.getLogger(DueDateExternalService.class.getName());
+
+    private final String camundaUrl;
+    private final DueDateService dueDateService;
+
+    public DueDateExternalService(
+        @Value("${camunda.url}") String camundaUrl,
+        DueDateService dueDateService
+    ) {
+        this.camundaUrl = camundaUrl;
+        this.dueDateService = dueDateService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void setupClient() {
+        ExternalTaskClient client = ExternalTaskClient.create()
+            .baseUrl(camundaUrl)
+            .asyncResponseTimeout(10000)
+            .build();
+
+        client.subscribe("calculate-due-date")
+            .lockDuration(1000)
+            .handler(this::workingDaysHandler)
+            .open();
+    }
+
+    public void workingDaysHandler(ExternalTask externalTask, ExternalTaskService externalTaskService) {
+        int workingDaysAllowed = (int)((Map<?, ?>) externalTask.getVariable("task")).get("workingDaysAllowed");
+
+        ZonedDateTime dueDate = dueDateService.addWorkingDays(workingDaysAllowed);
+
+        Map<String, Object> processVariables = singletonMap(
+            "overdueTaskDueDate",
+            dueDate.format(DateTimeFormatter.ISO_INSTANT)
+        );
+
+        LOGGER.info("Overdue task has due date of " + dueDate.format(DateTimeFormatter.ISO_INSTANT));
+        externalTaskService.complete(externalTask, processVariables);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateService.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.HolidayService;
+import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.TaskToCreate;
+
+import java.time.DayOfWeek;
+import java.time.ZonedDateTime;
+
+@Component
+public class DueDateService {
+
+    private final DateService dateService;
+    private final HolidayService holidayService;
+
+    public DueDateService(DateService dateService, HolidayService holidayService) {
+        this.dateService = dateService;
+        this.holidayService = holidayService;
+    }
+
+    public ZonedDateTime calculateDueDate(ZonedDateTime dueDate, TaskToCreate taskToCreate) {
+        if (dueDate != null) {
+            return dueDate;
+        }
+        int workingDaysAllowed = taskToCreate.getWorkingDaysAllowed();
+        if (workingDaysAllowed == 0) {
+            throw new IllegalStateException(
+                "Should either have a due date or have got the working days allowed for task"
+            );
+        }
+        return addWorkingDays(dateService.now(), workingDaysAllowed);
+    }
+
+    private ZonedDateTime addWorkingDays(ZonedDateTime startDate, int numberOfDays) {
+        if (numberOfDays == 0) {
+            return startDate;
+        }
+
+        ZonedDateTime newDate = startDate.plusDays(1);
+        if (isWeekend(newDate) || holidayService.isHoliday(newDate)) {
+            return addWorkingDays(newDate, numberOfDays);
+        } else {
+            return addWorkingDays(newDate, numberOfDays - 1);
+        }
+    }
+
+    private boolean isWeekend(ZonedDateTime date) {
+        return date.getDayOfWeek() == DayOfWeek.SATURDAY || date.getDayOfWeek() == DayOfWeek.SUNDAY;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateService.java
@@ -28,7 +28,11 @@ public class DueDateService {
                 "Should either have a due date or have got the working days allowed for task"
             );
         }
-        return addWorkingDays(dateService.now(), workingDaysAllowed);
+        return addWorkingDays(workingDaysAllowed);
+    }
+
+    public ZonedDateTime addWorkingDays(int numberOfDays) {
+        return addWorkingDays(dateService.now(), numberOfDays);
     }
 
     private ZonedDateTime addWorkingDays(ZonedDateTime startDate, int numberOfDays) {

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/RealDateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/RealDateService.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+@Component
+public class RealDateService implements DateService {
+    @Override
+    public ZonedDateTime now() {
+        return ZonedDateTime.now();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/CountryHolidayDates.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/CountryHolidayDates.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import java.util.List;
+import java.util.Objects;
+
+public class CountryHolidayDates {
+    private List<HolidayDate> events;
+
+    private CountryHolidayDates() {
+    }
+
+    public CountryHolidayDates(List<HolidayDate> events) {
+        this.events = events;
+    }
+
+    public List<HolidayDate> getEvents() {
+        return events;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        CountryHolidayDates that = (CountryHolidayDates) object;
+        return Objects.equals(events, that.events);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(events);
+    }
+
+    @Override
+    public String toString() {
+        return "CountryHolidayDates{"
+               + "events=" + events
+               + '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/GovUkHolidayDatesClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/GovUkHolidayDatesClient.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+    name = "GovUkHolidayDatesClient",
+    url = "${govUkHolidays.url}"
+)
+public interface GovUkHolidayDatesClient {
+    @GetMapping(value = "/bank-holidays.json", produces = MediaType.APPLICATION_JSON_VALUE)
+    UkHolidayDates getHolidayDates();
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayDate.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class HolidayDate {
+    private LocalDate date;
+
+    private HolidayDate() {
+    }
+
+    public HolidayDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        HolidayDate that = (HolidayDate) object;
+        return Objects.equals(date, that.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date);
+    }
+
+    @Override
+    public String toString() {
+        return "HolidayDate{"
+               + "date='" + date + '\''
+               + '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayLoader.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayLoader.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class HolidayLoader {
+    private final GovUkHolidayDatesClient govUkHolidayDatesClient;
+
+    public HolidayLoader(GovUkHolidayDatesClient govUkHolidayDatesClient) {
+        this.govUkHolidayDatesClient = govUkHolidayDatesClient;
+    }
+
+    @Bean
+    public List<LocalDate> loadHolidays() {
+        UkHolidayDates holidayDates = govUkHolidayDatesClient.getHolidayDates();
+        return holidayDates.getEnglandAndWales().getEvents().stream()
+            .map(HolidayDate::getDate)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayService.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Component
+public class HolidayService {
+    private final List<LocalDate> holidays;
+
+    public HolidayService(List<LocalDate> holidays) {
+        this.holidays = holidays;
+    }
+
+    public boolean isHoliday(ZonedDateTime zonedDateTime) {
+        return holidays.contains(zonedDateTime.toLocalDate());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/UkHolidayDates.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/UkHolidayDates.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class UkHolidayDates {
+    @JsonProperty("england-and-wales")
+    private CountryHolidayDates englandAndWales;
+
+    private UkHolidayDates() {
+    }
+
+    public UkHolidayDates(CountryHolidayDates englandAndWales) {
+        this.englandAndWales = englandAndWales;
+    }
+
+    public CountryHolidayDates getEnglandAndWales() {
+        return englandAndWales;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        UkHolidayDates that = (UkHolidayDates) object;
+        return Objects.equals(englandAndWales, that.englandAndWales);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(englandAndWales);
+    }
+
+    @Override
+    public String toString() {
+        return "UkHolidayDates{"
+               + "englandAndWales=" + englandAndWales
+               + '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/DmnValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/DmnValue.java
@@ -2,23 +2,27 @@ package uk.gov.hmcts.reform.waworkflowapi.external.taskservice;
 
 import java.util.Objects;
 
-public class DmnValue {
-    private String value;
+public class DmnValue<T> {
+    private T value;
     private String type;
 
-    public static DmnValue dmnStringValue(String value) {
-        return new DmnValue(value, "String");
+    public static DmnValue<String> dmnStringValue(String value) {
+        return new DmnValue<>(value, "String");
+    }
+
+    public static DmnValue<Integer> dmnIntegerValue(Integer value) {
+        return new DmnValue<>(value, "Integer");
     }
 
     private DmnValue() {
     }
 
-    public DmnValue(String value, String type) {
+    public DmnValue(T value, String type) {
         this.value = value;
         this.type = type;
     }
 
-    public String getValue() {
+    public T getValue() {
         return value;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/GetTaskDmnResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/GetTaskDmnResult.java
@@ -3,23 +3,29 @@ package uk.gov.hmcts.reform.waworkflowapi.external.taskservice;
 import java.util.Objects;
 
 public class GetTaskDmnResult {
-    private DmnValue taskId;
-    private DmnValue group;
+    private DmnValue<String> taskId;
+    private DmnValue<String> group;
+    private DmnValue<Integer> workingDaysAllowed;
 
     private GetTaskDmnResult() {
     }
 
-    public GetTaskDmnResult(DmnValue taskId, DmnValue group) {
+    public GetTaskDmnResult(DmnValue<String> taskId, DmnValue<String> group, DmnValue<Integer> workingDaysAllowed) {
         this.taskId = taskId;
         this.group = group;
+        this.workingDaysAllowed = workingDaysAllowed;
     }
 
-    public DmnValue getTaskId() {
+    public DmnValue<String> getTaskId() {
         return taskId;
     }
 
-    public DmnValue getGroup() {
+    public DmnValue<String> getGroup() {
         return group;
+    }
+
+    public DmnValue<Integer> getWorkingDaysAllowed() {
+        return workingDaysAllowed;
     }
 
     @Override
@@ -32,7 +38,8 @@ public class GetTaskDmnResult {
         }
         GetTaskDmnResult that = (GetTaskDmnResult) object;
         return Objects.equals(taskId, that.taskId)
-               && Objects.equals(group, that.group);
+               && Objects.equals(group, that.group)
+               && Objects.equals(workingDaysAllowed, that.workingDaysAllowed);
     }
 
     @Override
@@ -45,6 +52,7 @@ public class GetTaskDmnResult {
         return "GetTaskDmnResult{"
                + "taskId=" + taskId
                + ", group=" + group
+               + ", workingDaysAllowed=" + workingDaysAllowed
                + '}';
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/ProcessVariables.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/ProcessVariables.java
@@ -7,31 +7,31 @@ import java.util.Objects;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnStringValue;
 
 public class ProcessVariables {
-    private final DmnValue ccdId;
-    private final DmnValue task;
-    private final DmnValue group;
-    private final DmnValue dueDate;
+    private final DmnValue<String> ccdId;
+    private final DmnValue<String> taskId;
+    private final DmnValue<String> group;
+    private final DmnValue<String> dueDate;
 
-    public ProcessVariables(String ccdId, Task task, String group, ZonedDateTime dueDate) {
+    public ProcessVariables(String ccdId, Task taskId, String group, ZonedDateTime dueDate) {
         this.ccdId = dmnStringValue(ccdId);
-        this.task = dmnStringValue(task.getId());
+        this.taskId = dmnStringValue(taskId.getId());
         this.group = dmnStringValue(group);
         this.dueDate = dmnStringValue(dueDate.format(DateTimeFormatter.ISO_INSTANT));
     }
 
-    public DmnValue getCcdId() {
+    public DmnValue<String> getCcdId() {
         return ccdId;
     }
 
-    public DmnValue getTask() {
-        return task;
+    public DmnValue<String> getTaskId() {
+        return taskId;
     }
 
-    public DmnValue getGroup() {
+    public DmnValue<String> getGroup() {
         return group;
     }
 
-    public DmnValue getDueDate() {
+    public DmnValue<String> getDueDate() {
         return dueDate;
     }
 
@@ -45,21 +45,21 @@ public class ProcessVariables {
         }
         ProcessVariables that = (ProcessVariables) object;
         return Objects.equals(ccdId, that.ccdId)
-               && Objects.equals(task, that.task)
+               && Objects.equals(taskId, that.taskId)
                && Objects.equals(group, that.group)
                && Objects.equals(dueDate, that.dueDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ccdId, task);
+        return Objects.hash(ccdId, taskId);
     }
 
     @Override
     public String toString() {
         return "ProcessVariables{"
                + "ccdId=" + ccdId
-               + ", task=" + task
+               + ", taskId=" + taskId
                + ", group=" + group
                + ", dueDate=" + dueDate
                + '}';

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/ProcessVariables.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/ProcessVariables.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.waworkflowapi.external.taskservice;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnStringValue;
@@ -10,11 +12,11 @@ public class ProcessVariables {
     private final DmnValue group;
     private final DmnValue dueDate;
 
-    public ProcessVariables(String ccdId, Task task, String group, String dueDate) {
+    public ProcessVariables(String ccdId, Task task, String group, ZonedDateTime dueDate) {
         this.ccdId = dmnStringValue(ccdId);
         this.task = dmnStringValue(task.getId());
         this.group = dmnStringValue(group);
-        this.dueDate = dmnStringValue(dueDate);
+        this.dueDate = dmnStringValue(dueDate.format(DateTimeFormatter.ISO_INSTANT));
     }
 
     public DmnValue getCcdId() {

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/Task.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/Task.java
@@ -14,7 +14,14 @@ public enum Task {
     REVIEW_RESPONDENT_RESPONSE("reviewRespondentResponse"),
     CREATE_CASE_SUMMARY("createCaseSummary"),
     CREATE_HEARING_BUNDLE("createHearingBundle"),
-    START_DECISIONS_AND_REASONS_DOCUMENT("startDecisionsAndReasonsDocument")
+    START_DECISIONS_AND_REASONS_DOCUMENT("startDecisionsAndReasonsDocument"),
+    PROVIDE_RESPONDENT_EVIDENCE("provideRespondentEvidence"),
+    PROVIDE_CASE_BUILDING("provideCaseBuilding"),
+    PROVIDE_REASONS_FOR_APPEAL("provideReasonsForAppeal"),
+    PROVIDE_CLARIFYING_ANSWERS("provideClarifyingAnswers"),
+    PROVIDE_CMA_REQUIREMENTS("provideCmaRequirements"),
+    PROVIDE_RESPONDENT_REVIEW("provideRespondentReview"),
+    PROVIDE_HEARING_REQUIREMENTS("provideHearingRequirements")
     ;
 
 

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,12 +36,16 @@ public class TaskClientService {
         } else if (dmnResults.size() == 1) {
             Task task = taskForId(dmnResults.get(0).getTaskId().getValue());
             String group = dmnResults.get(0).getGroup().getValue();
-            return Optional.of(new TaskToCreate(task, group));
+            DmnValue<Integer> workingDaysAllowed = dmnResults.get(0).getWorkingDaysAllowed();
+            return Optional.of((workingDaysAllowed == null)
+                                   ? new TaskToCreate(task, group)
+                                   : new TaskToCreate(task, group, workingDaysAllowed.getValue())
+            );
         }
         throw new IllegalStateException("Should have exactly one task for transition");
     }
 
-    public void createTask(String ccdId, TaskToCreate taskToCreate, String dueDate) {
+    public void createTask(String ccdId, TaskToCreate taskToCreate, ZonedDateTime dueDate) {
         ProcessVariables processVariables = new ProcessVariables(
             ccdId,
             taskToCreate.getTask(),

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskService.java
@@ -3,23 +3,28 @@ package uk.gov.hmcts.reform.waworkflowapi.external.taskservice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.DueDateService;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 @Component
 public class TaskService {
     private final TaskClientService taskClientService;
+    private final DueDateService dueDateService;
 
     @Autowired
-    public TaskService(TaskClientService taskClientService) {
+    public TaskService(TaskClientService taskClientService, DueDateService dueDateService) {
         this.taskClientService = taskClientService;
+        this.dueDateService = dueDateService;
     }
 
-    public boolean createTask(Transition transition, String caseId, String dueDate) {
+    public boolean createTask(Transition transition, String caseId, ZonedDateTime dueDate) {
         Optional<TaskToCreate> taskOptional = taskClientService.getTask(transition);
 
         return taskOptional.map(taskToCreate -> {
-            taskClientService.createTask(caseId, taskToCreate, dueDate);
+            ZonedDateTime calculatedDueDate = dueDateService.calculateDueDate(dueDate, taskToCreate);
+            taskClientService.createTask(caseId, taskToCreate, calculatedDueDate);
 
             return true;
         }).orElse(false);

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskToCreate.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskToCreate.java
@@ -5,10 +5,16 @@ import java.util.Objects;
 public class TaskToCreate {
     private final Task task;
     private final String group;
+    private final int workingDaysAllowed;
 
-    public TaskToCreate(Task task, String group) {
+    public TaskToCreate(Task task, String group, int workingDaysAllowed) {
         this.task = task;
         this.group = group;
+        this.workingDaysAllowed = workingDaysAllowed;
+    }
+
+    public TaskToCreate(Task task, String group) {
+        this(task, group, 0);
     }
 
     public Task getTask() {
@@ -17,6 +23,10 @@ public class TaskToCreate {
 
     public String getGroup() {
         return group;
+    }
+
+    public int getWorkingDaysAllowed() {
+        return workingDaysAllowed;
     }
 
     @Override
@@ -29,7 +39,8 @@ public class TaskToCreate {
         }
         TaskToCreate that = (TaskToCreate) object;
         return task == that.task
-               && Objects.equals(group, that.group);
+               && Objects.equals(group, that.group)
+               && Objects.equals(workingDaysAllowed, that.workingDaysAllowed);
     }
 
     @Override
@@ -42,6 +53,7 @@ public class TaskToCreate {
         return "TaskToCreate{"
                + "task=" + task
                + ", group='" + group + '\''
+               + ", workingDaysAllowed='" + workingDaysAllowed + '\''
                + '}';
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,9 @@ camunda:
   url: ${CAMUNDA_URL:http://localhost:8080/engine-rest}
   getTaskDmnId: getTask
 
+govUkHolidays:
+  url: https://www.gov.uk/
+
 #logging:
 #  level:
 #    org.springframework: debug

--- a/src/test/java/uk/gov/hmcts/reform/rsecheck/PojoTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/rsecheck/PojoTest.java
@@ -11,6 +11,9 @@ import pl.pojo.tester.internal.instantiator.ObjectGenerator;
 import pl.pojo.tester.internal.utils.ThoroughFieldPermutator;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.CreateTaskRequest;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.CountryHolidayDates;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.HolidayDate;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.UkHolidayDates;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnRequest;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnResult;
 import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue;
@@ -41,7 +44,10 @@ class PojoTest {
         GetTaskDmnResult.class,
         SendMessageRequest.class,
         ProcessVariables.class,
-        TaskToCreate.class
+        TaskToCreate.class,
+        CountryHolidayDates.class,
+        HolidayDate.class,
+        UkHolidayDates.class
     };
     // Cannot test equals for generic classes
     private final Class[] ignoreEquals = {
@@ -49,7 +55,10 @@ class PojoTest {
         DmnResult.class,
         SendMessageRequest.class,
         ProcessVariables.class,
-        TaskToCreate.class
+        TaskToCreate.class,
+        DmnValue.class,
+        GetTaskDmnRequest.class,
+        CreateTaskRequest.class
     };
     private final ObjectGenerator objectGenerator = new ObjectGenerator(
         DefaultFieldValueChanger.INSTANCE,
@@ -59,7 +68,7 @@ class PojoTest {
     private final EqualsTester equalsTester = new EqualsTester();
 
     @Test
-    public void allPojosAreWellImplemented() {
+    void allPojosAreWellImplemented() {
         assertPojoMethodsForAll(
             classesToTest
         )

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateExternalServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateExternalServiceTest.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.camunda.bpm.client.task.ExternalTask;
+import org.camunda.bpm.client.task.ExternalTaskService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DueDateExternalServiceTest {
+
+    private DueDateService dueDateService;
+    private ExternalTask externalTask;
+    private ExternalTaskService externalTaskService;
+    private int workingDaysAllowed;
+    private ZonedDateTime dueDate;
+
+    @BeforeEach
+    void setUp() {
+        dueDateService = mock(DueDateService.class);
+        externalTask = mock(ExternalTask.class);
+        externalTaskService = mock(ExternalTaskService.class);
+        workingDaysAllowed = 2;
+        dueDate = ZonedDateTime.now();
+    }
+
+    @Test
+    void testWorkingDaysHandler() {
+        DueDateExternalService dueDateExternalService = new DueDateExternalService("someUrl", dueDateService);
+
+        when(externalTask.getVariable("task")).thenReturn(singletonMap("workingDaysAllowed", workingDaysAllowed));
+        when(dueDateService.addWorkingDays(workingDaysAllowed)).thenReturn(dueDate);
+
+        dueDateExternalService.workingDaysHandler(externalTask, externalTaskService);
+
+        Map<String, Object> expectedProcessVariables = singletonMap("overdueTaskDueDate", dueDate.format(ISO_INSTANT));
+        verify(externalTaskService).complete(externalTask, expectedProcessVariables);
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateServiceTest.java
@@ -1,0 +1,160 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.HolidayService;
+import uk.gov.hmcts.reform.waworkflowapi.external.taskservice.TaskToCreate;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.PROCESS_APPLICATION;
+
+@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
+class DueDateServiceTest {
+
+    public static final String TCW_GROUP = "TCW";
+    private FixedDateService dateService;
+    private DueDateService underTest;
+    private HolidayService holidayService;
+
+    @BeforeEach
+    void setUp() {
+        dateService = new FixedDateService();
+        holidayService = mock(HolidayService.class);
+        underTest = new DueDateService(dateService, holidayService);
+    }
+
+    @Test
+    void haveToSetEitherADueDateOrHaveWorkingDays() {
+        assertThrows(IllegalStateException.class, () -> {
+            underTest.calculateDueDate(
+                null,
+                new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP)
+            );
+        });
+
+    }
+
+    @Test
+    void ifADueDateIsAlreadySetDoNotCalculateANewOne() {
+        ZonedDateTime providedDueDate = ZonedDateTime.now();
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            providedDueDate,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP)
+        );
+
+        assertThat(calculatedDueDate, is(providedDueDate));
+    }
+
+    @Test
+    void calculateDueDateAllWorkingDays() {
+        int leadTimeDays = 2;
+        ZonedDateTime now = ZonedDateTime.of(2020, 9, 1, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(now);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        assertThat(calculatedDueDate, is(now.plusDays(leadTimeDays)));
+    }
+
+    @Test
+    void calculateDueDateWhenFallInAWeekend() {
+        int leadTimeDays = 2;
+        ZonedDateTime now = ZonedDateTime.of(2020, 9, 3, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(now);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 7, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+
+    @Test
+    void calculateDueDateWhenStraddlesAWeekend() {
+        int leadTimeDays = 4;
+        ZonedDateTime now = ZonedDateTime.of(2020, 9, 3, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(now);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 9, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+
+    @Test
+    void calculateDueDateWhichStraddlesMultipleWeekends() {
+        int leadTimeDays = 10;
+        ZonedDateTime now = ZonedDateTime.of(2020, 9, 3, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(now);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 17, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+
+    @Test
+    void calculateDueDateWhichFallsOnAWeekend() {
+        int leadTimeDays = 10;
+        ZonedDateTime now = ZonedDateTime.of(2020, 9, 3, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(now);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 17, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+
+    @Test
+    void calculateDueDateWhichFallsOnAHoliday() {
+        int leadTimeDays = 2;
+        ZonedDateTime startDay = ZonedDateTime.of(2020, 9, 1, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(startDay);
+        when(holidayService.isHoliday(ZonedDateTime.of(2020, 9, 3, 1, 2, 3, 4, ZoneId.systemDefault()))).thenReturn(true);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 4, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+
+    @Test
+    void calculateDueDateWhichStraddlesAHoliday() {
+        int leadTimeDays = 2;
+        ZonedDateTime startDay = ZonedDateTime.of(2020, 9, 1, 1, 2, 3, 4, ZoneId.systemDefault());
+        dateService.setCurrentDateTime(startDay);
+        when(holidayService.isHoliday(startDay.plusDays(1))).thenReturn(true);
+
+        ZonedDateTime calculatedDueDate = underTest.calculateDueDate(
+            null,
+            new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP, leadTimeDays)
+        );
+
+        ZonedDateTime theFollowingMonday = ZonedDateTime.of(2020, 9, 4, 1, 2, 3, 4, ZoneId.systemDefault());
+        assertThat(calculatedDueDate, is(theFollowingMonday));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/DueDateServiceTest.java
@@ -32,10 +32,11 @@ class DueDateServiceTest {
 
     @Test
     void haveToSetEitherADueDateOrHaveWorkingDays() {
+        TaskToCreate taskToCreate = new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP);
         assertThrows(IllegalStateException.class, () -> {
             underTest.calculateDueDate(
                 null,
-                new TaskToCreate(PROCESS_APPLICATION, TCW_GROUP)
+                taskToCreate
             );
         });
 

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/FixedDateService.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/FixedDateService.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import java.time.ZonedDateTime;
+
+public class FixedDateService implements DateService {
+
+    private ZonedDateTime currentDateTime;
+
+    public void setCurrentDateTime(ZonedDateTime currentDateTime) {
+        this.currentDateTime = currentDateTime;
+    }
+
+    @Override
+    public ZonedDateTime now() {
+        return currentDateTime;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/HolidayServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/HolidayServiceTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates.HolidayService;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static java.time.ZoneId.systemDefault;
+import static java.time.ZonedDateTime.of;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
+class HolidayServiceTest {
+    @Test
+    void isNotHoliday() {
+        ZonedDateTime date = of(2020, 9, 1, 1, 2, 3, 4, systemDefault());
+        boolean isHoliday = new HolidayService(singletonList(LocalDate.of(2020, 9, 2))).isHoliday(date);
+
+        assertThat(isHoliday, is(false));
+    }
+
+    @Test
+    void isHoliday() {
+        ZonedDateTime date = of(2020, 9, 1, 1, 2, 3, 4, systemDefault());
+        boolean isHoliday = new HolidayService(singletonList(LocalDate.of(2020, 9, 1))).isHoliday(date);
+
+        assertThat(isHoliday, is(true));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayLoaderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/duedate/holidaydates/HolidayLoaderTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.waworkflowapi.duedate.holidaydates;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
+class HolidayLoaderTest {
+    @Test
+    void loadData() {
+        GovUkHolidayDatesClient govUkHolidayDatesClient = mock(GovUkHolidayDatesClient.class);
+        LocalDate holiday = LocalDate.now();
+        when(govUkHolidayDatesClient.getHolidayDates()).thenReturn(
+            new UkHolidayDates(new CountryHolidayDates(singletonList(new HolidayDate(holiday))))
+        );
+        List<LocalDate> holidays = new HolidayLoader(govUkHolidayDatesClient).loadHolidays();
+
+        assertThat(holidays, is(singletonList(holiday)));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientServiceTest.java
@@ -6,7 +6,6 @@ import org.mockito.Mockito;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnIntegerValue;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dmnStringValue;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.PROCESS_APPLICATION;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.taskForId;
@@ -45,9 +45,27 @@ class TaskClientServiceTest {
     }
 
     @Test
-    void getsATaskBasedOnTransition() {
-        List<GetTaskDmnResult> ts = singletonList(new GetTaskDmnResult(dmnStringValue(expectedTask),
-                                                                       dmnStringValue(GROUP)));
+    void getsATaskWithWorkingDaysBasedOnTransition() {
+        int workingDaysAllowed = 5;
+        List<GetTaskDmnResult> ts = singletonList(new GetTaskDmnResult(
+            dmnStringValue(expectedTask),
+            dmnStringValue(GROUP),
+            dmnIntegerValue(workingDaysAllowed)
+        ));
+        when(camundaClient.getTask(dmnRequest)).thenReturn(ts);
+
+        Optional<TaskToCreate> task = underTest.getTask(transition);
+
+        assertThat(task, is(Optional.of(new TaskToCreate(taskForId(expectedTask), GROUP, workingDaysAllowed))));
+    }
+
+    @Test
+    void getsATaskWithoutWorkingDaysBasedOnTransition() {
+        List<GetTaskDmnResult> ts = singletonList(new GetTaskDmnResult(
+            dmnStringValue(expectedTask),
+            dmnStringValue(GROUP),
+            null
+        ));
         when(camundaClient.getTask(dmnRequest)).thenReturn(ts);
 
         Optional<TaskToCreate> task = underTest.getTask(transition);
@@ -67,7 +85,7 @@ class TaskClientServiceTest {
 
     @Test
     void getsMultipleTasksBasedOnTransitionWhichIsInvalid() {
-        GetTaskDmnResult dmnResult = new GetTaskDmnResult(dmnStringValue(expectedTask), dmnStringValue("TCW"));
+        GetTaskDmnResult dmnResult = new GetTaskDmnResult(dmnStringValue(expectedTask), dmnStringValue("TCW"), dmnIntegerValue(5));
         List<GetTaskDmnResult> ts = asList(dmnResult, dmnResult);
         when(camundaClient.getTask(dmnRequest)).thenReturn(ts);
 
@@ -80,11 +98,14 @@ class TaskClientServiceTest {
     void createsATask() {
         String ccdId = "ccd_id";
         String group = "TCW";
-        String dueDate = ZonedDateTime.now().plusDays(2).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        ZonedDateTime dueDate = ZonedDateTime.now().plusDays(2);
         underTest.createTask(ccdId, new TaskToCreate(PROCESS_APPLICATION, group), dueDate);
 
         Mockito.verify(camundaClient).sendMessage(
-            new SendMessageRequest("createTaskMessage", new ProcessVariables(ccdId, PROCESS_APPLICATION, group, dueDate))
+            new SendMessageRequest(
+                "createTaskMessage",
+                new ProcessVariables(ccdId, PROCESS_APPLICATION, group, dueDate)
+            )
         );
     }
 }

--- a/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequest.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.waworkflowapi.api;
+
+import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
+
+public class CreateTaskRequest {
+    private final String caseId;
+    private final Transition transition;
+    private final String dueDate;
+
+    public CreateTaskRequest(String caseId, Transition transition, String dueDate) {
+        this.caseId = caseId;
+        this.transition = transition;
+        this.dueDate = dueDate;
+    }
+
+    public String getCaseId() {
+        return caseId;
+    }
+
+    public Transition getTransition() {
+        return transition;
+    }
+
+    public String getDueDate() {
+        return dueDate;
+    }
+}

--- a/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequestBuilder.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequestBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.waworkflowapi.api;
 
-import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.CreateTaskRequest;
 import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.Transition;
 
 import java.time.ZonedDateTime;
@@ -29,11 +28,11 @@ public final class CreateTaskRequestBuilder {
     }
 
     public CreateTaskRequestBuilder withDueDate(ZonedDateTime dueDate) {
-        this.dueDate = dueDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        this.dueDate = dueDate.format(DateTimeFormatter.ISO_INSTANT);
         return this;
     }
 
-    public CreateTaskRequest build() {
+    public uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequest build() {
         return new CreateTaskRequest(caseId, transition, dueDate);
     }
 }

--- a/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequestCreator.java
+++ b/src/testUtils/java/uk/gov/hmcts/reform/waworkflowapi/api/CreateTaskRequestCreator.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.waworkflowapi.api;
 
-import uk.gov.hmcts.reform.waworkflowapi.controllers.startworkflow.CreateTaskRequest;
-
 import java.time.ZonedDateTime;
 
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestBuilder.aCreateTaskRequest;
@@ -33,6 +31,20 @@ public final class CreateTaskRequestCreator {
                     .withPreState("appealStarted")
                     .withEventId("submitAppeal")
                     .withPostState("appealSubmitted")
+                    .build()
+            )
+            .withDueDate(ZonedDateTime.now().plusDays(2))
+            .build();
+    }
+
+    public static CreateTaskRequest requestRespondentEvidenceTaskRequest(String caseId) {
+        return aCreateTaskRequest()
+            .withCaseId(caseId)
+            .withTransition(
+                aTransition()
+                    .withPreState("appealSubmitted")
+                    .withEventId("requestRespondentEvidence")
+                    .withPostState("awaitingRespondentEvidence")
                     .build()
             )
             .withDueDate(ZonedDateTime.now().plusDays(2))


### PR DESCRIPTION
Calculate the due for a task based on the working days.

If a request to create a task is made with a due date that is used, otherwise
the config contains the number of days for the the task. Calculate the due
date of the task based on working days.

For now working days are days that are not a weekend or not a holiday in
England or wales based on gov uk holiday dates. Holidays in other parts of
the country will need to be handled in a separate story.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-78

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
