### PR TITLE
Pmd: Cleanup and Re-enable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,8 +127,7 @@ checkstyle {
 
 pmd {
   toolVersion = "6.18.0"
-  ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
+  sourceSets = [sourceSets.main]
   reportsDir = file("$project.buildDir/reports/pmd")
   // https://github.com/pmd/pmd/issues/876
   ruleSets = []

--- a/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/something/CreateTaskTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/waworkflowapi/features/something/CreateTaskTest.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.app
 import static uk.gov.hmcts.reform.waworkflowapi.api.CreateTaskRequestCreator.unmappedCreateTaskRequest;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class CreateTaskTest {
 
     private final String testUrl = System.getenv("TEST_URL") == null ? "http://localhost:8099" :  System.getenv("TEST_URL");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaCreateTaskTest.java
@@ -24,7 +24,6 @@ import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.hmcts.reform.waworkflowapi.ProcessEngineBuilder.getProcessEngine;
 
-@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.UseConcurrentHashMap" })
 public class CamundaCreateTaskTest {
 
     public static final String PROCESS_TASK = "processTask";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetOverdueTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetOverdueTaskTest.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
 class CamundaGetOverdueTaskTest {
 
     private DmnEngine dmnEngine;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/CamundaGetTaskTest.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
 class CamundaGetTaskTest {
 
     private DmnEngine dmnEngine;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/config/SwaggerPublisherTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/config/SwaggerPublisherTest.java
@@ -29,7 +29,6 @@ class SwaggerPublisherTest {
 
     @DisplayName("Generate swagger documentation")
     @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void generateDocs() throws Exception {
         byte[] specs = mvc.perform(get("/v2/api-docs"))
             .andExpect(status().isOk())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/controllers/CreateTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/waworkflowapi/controllers/CreateTaskTest.java
@@ -34,7 +34,6 @@ import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.PROCES
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class CreateTaskTest {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
@@ -32,7 +32,7 @@ public class TaskClientService {
 
         if (dmnResults.isEmpty()) {
             return Optional.empty();
-        } else if (dmnResults.size() == 1) {
+        } else if (dmnResults.size() > 1) {
             Task task = taskForId(dmnResults.get(0).getTaskId().getValue());
             String group = dmnResults.get(0).getGroup().getValue();
             return Optional.of(new TaskToCreate(task, group));

--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientService.java
@@ -32,7 +32,7 @@ public class TaskClientService {
 
         if (dmnResults.isEmpty()) {
             return Optional.empty();
-        } else if (dmnResults.size() > 1) {
+        } else if (dmnResults.size() == 1) {
             Task task = taskForId(dmnResults.get(0).getTaskId().getValue());
             String group = dmnResults.get(0).getGroup().getValue();
             return Optional.of(new TaskToCreate(task, group));

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/PojoTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/PojoTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static pl.pojo.tester.api.assertion.Assertions.assertPojoMethodsForAll;
 
-@SuppressWarnings({"unchecked", "PMD.JUnitTestsShouldIncludeAssert", "PMD.DataflowAnomalyAnalysis", "PMD.EqualsNull", "PMD.AvoidInstantiatingObjectsInLoops"})
 class PojoTest {
 
     private final Class[] classesToTest = {

--- a/src/test/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/waworkflowapi/external/taskservice/TaskClientServiceTest.java
@@ -22,7 +22,6 @@ import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.DmnValue.dm
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.PROCESS_APPLICATION;
 import static uk.gov.hmcts.reform.waworkflowapi.external.taskservice.Task.taskForId;
 
-@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
 class TaskClientServiceTest {
 
     private CamundaClient camundaClient;


### PR DESCRIPTION
### Change description ###

Re-enables pmd failures changed source set to only scan src/main and cleanup

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
