### PR TITLE
Log exception message even if we don't log the exception.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/advice/ErrorLogger.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/controllers/advice/ErrorLogger.java
@@ -19,6 +19,8 @@ public class ErrorLogger {
     public void maybeLogException(Throwable ex) {
         if (stacktraceEnabled) {
             LOG.error("Exception occurred: {}", ex.getMessage(), ex);
+        } else {
+            LOG.error("Exception occurred: {}", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Log exception message even if we don't log the exception.