### PR TITLE
Enable long-polling with 1 sec timeout 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/waworkflowapi/clients/service/ExternalTaskWorker.java
+++ b/src/main/java/uk/gov/hmcts/reform/waworkflowapi/clients/service/ExternalTaskWorker.java
@@ -42,6 +42,7 @@ public class ExternalTaskWorker {
 
         ExternalTaskClient idempotencyClient = ExternalTaskClient.create()
             .baseUrl(camundaUrl)
+            .asyncResponseTimeout(1000)
             .addInterceptor(new ServiceAuthProviderInterceptor(authTokenGenerator))
             .backoffStrategy(new ExponentialBackoffStrategy(2000L, 2, 8000L))
             .lockDuration(30000) // 30 seconds
@@ -55,6 +56,7 @@ public class ExternalTaskWorker {
 
         ExternalTaskClient warningClient = ExternalTaskClient.create()
             .baseUrl(camundaUrl)
+            .asyncResponseTimeout(1000)
             .addInterceptor(new ServiceAuthProviderInterceptor(authTokenGenerator))
             .backoffStrategy(new ExponentialBackoffStrategy(2000L, 2, 8000L))
             .lockDuration(30000) // 30 seconds


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Enable long-polling with 1 sec timeout to pick up messages from external tasks immediately

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
