### PR TITLE
RWA-872 Updating suppression date for false positive CVE-2020-23171

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,7 +8,7 @@
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>
-  <suppress until="2021-10-25">
+  <suppress until="2021-11-30">
     <notes><![CDATA[
      Suppressing as it's a false positive (see: https://github.com/jeremylong/DependencyCheck/issues/3594)
    ]]></notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-873

### Change description ###

Updated suppression date for CVE, increased to 1st Feb 2022 due to infrequent release cycle of lang-tags library which is causing the issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
