### PR TITLE
for CVE-2020-23171 com.nimbusds warning suppressed until 5 Jan

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,7 +8,7 @@
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>
-  <suppress until="2021-11-30">
+  <suppress until="2022-01-05">
     <notes><![CDATA[
      Suppressing as it's a false positive (see: https://github.com/jeremylong/DependencyCheck/issues/3594)
    ]]></notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-961

### Change description ###
for CVE-2020-23171 com.nimbusds warning suppressed until 5 Jan

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
