### PR TITLE
RWA-1310 Suppress CVE-2013-4152 and CVE-2013-4152

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -59,4 +59,18 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2022-21724</cve>
   </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-hateoas-1.4.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+    <cve>CVE-2013-4152</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2013-4152</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -68,9 +68,37 @@
   </suppress>
   <suppress until="2022-06-01">
     <notes><![CDATA[
+   file name: spring-hateoas-1.4.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+    <cve>CVE-2013-7315</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-hateoas-1.4.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+    <cve>CVE-2014-0054</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
    file name: spring-plugin-core-2.0.0.RELEASE.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
     <cve>CVE-2013-4152</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2013-7315</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2014-0054</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1310


### Change description ###
RWA-1310 Suppress CVE-2013-4152 and CVE-2013-4152 as the affected libraries are already on the latest versions, set suppression until 2022-06-01.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
