### PR TITLE
RWA-1333 address CVE-2022-22968 and CVE-2022-22965

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.6'
+  id 'org.springframework.boot' version '2.6.7'
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -123,4 +123,18 @@
     <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
     <cve>CVE-2022-22965</cve>
   </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-hateoas-1.4.2.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+    <cve>CVE-2022-22968</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2022-22968</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -105,4 +105,22 @@
     <notes>Doesn't apply to this project. Reference: https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker</notes>
     <cve>CVE-2016-1000027</cve>
   </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-hateoas-1.4.1.jar
+   ]]>
+      Doesn't apply since deployment is not a WAR
+    </notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.hateoas/spring\-hateoas@.*$</packageUrl>
+    <cve>CVE-2022-22965</cve>
+  </suppress>
+  <suppress until="2022-06-01">
+    <notes><![CDATA[
+   file name: spring-plugin-core-2.0.0.RELEASE.jar
+   ]]>
+      Doesn't apply since deployment is not a WAR
+    </notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
+    <cve>CVE-2022-22965</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1333


### Change description ###
Upgraded spring boot patch version to address CVE-2022-22968 and added suppressions for CVE-2022-22965 as it only applies to WAR deployments


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
