### PR TITLE
RWA-1411: tomcat upgrade due to CVE-2022-29885

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,8 +339,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.2'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.58'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.5.Final'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1411


### Change description ###
RWA-1411: upgraded tomcat-embed-core and tomcat-embed-websocket due to CVE-2022-29885


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
