### PR TITLE
RWA-1569 - Suppression of CVE-2022-34305 and upgrade tomcat to 9.0.64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,8 +328,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.2'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.63'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.63'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.64'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.64'
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.5.Final'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,4 +46,8 @@
         https://tanzu.vmware.com/security/cve-2022-22978</notes>
       <cve>CVE-2022-22978</cve>
     </suppress>
+    <suppress>
+      <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
+      <cve>CVE-2022-34305</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1569


### Change description ###

https://tools.hmcts.net/jira/browse/RWA-1569

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
