### PR TITLE
RWA-1752

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,8 @@ ext.libraries = [
   ]
 ]
 
+ext['snakeyaml.version'] = '1.31'
+
 dependencies {
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -54,4 +54,9 @@
       <notes>False positive log4j-api-2.17.2.jar and log4j-to-slf4j-2.17.2.jar</notes>
       <cve>CVE-2022-33915</cve>
     </suppress>
+    <suppress>
+      <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
+      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+      <cve>CVE-2022-25857</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1752


### Change description ###
Upgraded snakeyaml due to [CVE-2022-25857](https://github.com/advisories/GHSA-3mc7-4q67-w48m)
Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
