### PR TITLE
Upgraded launchdarkly-java-server-sdk 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.13.RELEASE'
   id 'org.springframework.boot' version '2.7.3'
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.owasp.dependencycheck' version '7.1.2'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'org.sonarqube' version '3.4.0.2513'
   id 'info.solidsoft.pitest' version '1.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ dependencies {
 
   implementation group: 'javax.xml', name: 'jaxb-api', version: '2.1'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.9.0'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,4 +7,39 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
         <vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
     </suppress>
+    <suppress>
+      <notes>Unauthorized Access with Spring Security Method Security</notes>
+      <cve>CVE-2018-1258</cve>
+    </suppress>
+    <suppress>
+      <notes>Changing SecurityContext More Than Once in Single Request Can Fail to Save</notes>
+      <cve>CVE-2021-22112</cve>
+    </suppress>
+    <suppress>
+      <notes>Doesn't apply to this project. Reference:
+        https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker
+      </notes>
+      <cve>CVE-2016-1000027</cve>
+    </suppress>
+    <suppress>
+      <notes>This project doesn't use BCrypt / BCryptPasswordEncoder  class
+        https://nvd.nist.gov/vuln/detail/CVE-2022-22976
+        https://tanzu.vmware.com/security/cve-2022-22976
+      </notes>
+      <cve>CVE-2022-22976</cve>
+    </suppress>
+    <suppress>
+      <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
+      <cve>CVE-2022-34305</cve>
+    </suppress>
+    <suppress>
+      <notes>CVE-2022-22978 suppression (false positive), because spring security already at (5.7.1) this is higher than the vulnerable versions
+        (5.5.x prior to 5.5.7, 5.6.x prior to 5.6.4)
+        https://tanzu.vmware.com/security/cve-2022-22978</notes>
+      <cve>CVE-2022-22978</cve>
+    </suppress>
+    <suppress>
+      <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
+      <cve>CVE-2022-34305</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,62 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2030-01-01">
-        <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-        <gav regex="true">^org.springframework.security:spring-security-*.*</gav>
-        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
     <suppress>
         <notes><![CDATA[
    file name: spring-security-core-5.4.9.jar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
         <vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>Additional Log Injection in Spring Framework</notes>
-        <cve>CVE-2021-22060</cve>
-    </suppress>
-    <suppress>
-        <notes>Unauthorized Access with Spring Security Method Security</notes>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-    <suppress>
-        <notes>Changing SecurityContext More Than Once in Single Request Can Fail to Save</notes>
-        <cve>CVE-2021-22112</cve>
-    </suppress>
-    <suppress>
-        <notes>Doesn't apply to this project. Reference:
-            https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker
-        </notes>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
-    <suppress>
-      <notes>This project doesn't use BCrypt / BCryptPasswordEncoder  class
-        https://nvd.nist.gov/vuln/detail/CVE-2022-22976
-        https://tanzu.vmware.com/security/cve-2022-22976
-      </notes>
-      <cve>CVE-2022-22976</cve>
-    </suppress>
-    <suppress>
-      <notes>CVE-2022-22978 suppression (false positive), because spring security already at (5.7.1) this is higher than the vulnerable versions
-        (5.5.x prior to 5.5.7, 5.6.x prior to 5.6.4)
-        https://tanzu.vmware.com/security/cve-2022-22978</notes>
-      <cve>CVE-2022-22978</cve>
-    </suppress>
-    <suppress>
-      <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
-      <cve>CVE-2022-34305</cve>
-    </suppress>
-    <suppress>
-      <notes>False positive log4j-api-2.17.2.jar and log4j-to-slf4j-2.17.2.jar</notes>
-      <cve>CVE-2022-33915</cve>
-    </suppress>
-    <suppress>
-      <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-      <cve>CVE-2022-25857</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1776


### Change description ###
upgraded launchdarkly-java-server-sdk  due to CVE-2022-38749, CVE-2022-38751, CVE-2022-38750


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
