### PR TITLE
Terraform deployment_namespace fix

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -12,7 +12,9 @@ variable "env" {}
 
 variable "subscription" {}
 
-variable "deployment_namespace" {}
+variable "deployment_namespace" {
+  default = ""
+}
 
 variable "common_tags" {
   type = map(string)


### PR DESCRIPTION
### Change description ###
Added required default value to deployment_namespace  in terraform script


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
