### PR TITLE
RWA-1871: CVE-2022-42003 suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.13.RELEASE'
   id 'org.springframework.boot' version '2.7.4'
-  id 'org.owasp.dependencycheck' version '7.1.2'
+  id 'org.owasp.dependencycheck' version '7.2.1'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'org.sonarqube' version '3.4.0.2513'
   id 'info.solidsoft.pitest' version '1.9.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -27,4 +27,8 @@
       https://tanzu.vmware.com/security/cve-2022-22978</notes>
     <cve>CVE-2022-22978</cve>
   </suppress>
+  <suppress>
+    <notes>Suppressed, because no fixed release yet and affected feature UNWRAP_SINGLE_VALUE_ARRAYS is disabled by default and not used in the project</notes>
+    <cve>CVE-2022-42003</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1871


### Change description ###
CVE-2022-42003 suppression,
org.owasp.dependencycheck upgrade to 7.2.1


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
