### PR TITLE
RWA-2059 - CVE FIX - CVE-2022-41946 - upgrade postgresql 42.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,7 +317,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.1.0'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '11.10'
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.4.0'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
 
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-2059

### Change description ###

CVE FIX - CVE-2022-41946 - upgrade postgresql 42.5.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
