### PR TITLE
RWA-2410: Suppress CVE-2022-1471

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -65,4 +65,10 @@
     </notes>
     <cve>CVE-2023-24998</cve>
   </suppress>
+  <suppress>
+    <notes>
+      com.launchdarkly:launchdarkly-java-server-sdk:5.10.2 is directly used by spring-boot-starter-json 2.7.7, spring boot 3 needed
+    </notes>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-2410

### Change description ###

Suppress CVE CVE-2022-1471, the snakeyml version referred via launchdarkly-java-server-sdk:5.10.2 is directly used by spring-boot-starter-json 2.7.7. Needed a spring-boot upgrade to fix this suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
