### PR TITLE
RWA-2487: rollback of renovate update of junit to unblock mutation tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,6 @@
     }
   ],
   "platformAutomerge": true,
-  "automerge": true,
+  "automerge": false,
   "automergeType": "pr"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '2.7.10'
+  id 'org.springframework.boot' version '2.7.11'
   id 'org.owasp.dependencycheck' version '8.2.1'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'org.sonarqube' version '3.5.0.2730'
@@ -240,7 +240,7 @@ dependencyManagement {
 
     dependency group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
-    dependencySet( group: 'org.springframework.security', version: '5.7.5'){
+    dependencySet( group: 'org.springframework.security', version: '5.7.8'){
       entry 'spring-boot-starter-security'
       entry 'spring-security-core'
       entry 'spring-security-acl'

--- a/build.gradle
+++ b/build.gradle
@@ -273,7 +273,7 @@ repositories {
 }
 
 def versions = [
-  junit         : '5.9.2',
+  junit         : '5.9.0',
   junitPlatform : '1.9.2',
   reformLogging : '5.1.9',
   springDoc     : '1.7.0',

--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ def versions = [
   springDoc     : '1.7.0',
   serenity      : '3.2.0',
   gradlePitest  : '1.9.0',
-  pitest        : '1.9.6',
+  pitest        : '1.12.0',
   sonarPitest   : '0.5',
   camunda       : '7.14.0',
   logbook       : '2.6.2',

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ dependencies {
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.15.Final'
 
-  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.18.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.19.0'
 
   implementation group: 'javax.xml', name: 'jaxb-api', version: '2.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ dependencies {
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.15.Final'
 
-  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.19.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.18.0'
 
   implementation group: 'javax.xml', name: 'jaxb-api', version: '2.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ dependencies {
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.15.Final'
 
-  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.19.0'
 
   implementation group: 'javax.xml', name: 'jaxb-api', version: '2.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ dependencies {
 
   implementation group: 'org.hibernate', name: 'hibernate-core', version: '5.6.15.Final'
 
-  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.18.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'
 
   implementation group: 'javax.xml', name: 'jaxb-api', version: '2.1'
 

--- a/charts/wa-workflow-api/Chart.yaml
+++ b/charts/wa-workflow-api/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for wa-workflow-api App
 name: wa-workflow-api
 home: https://github.com/hmcts/wa-workflow-api
-version: 0.0.28
+version: 0.0.29
 maintainers:
   - name: HMCTS wa team
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 4.1.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-2487

### Change description ###

Rollback of Junit 5 minor version to allow mutation tests to pass

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
