### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ repositories {
 def versions = [
   junit         : '5.9.0',
   junitPlatform : '1.9.2',
-  reformLogging : '5.1.9',
+  reformLogging : '6.0.1',
   springDoc     : '1.7.0',
   serenity      : '3.2.0',
   gradlePitest  : '1.9.11',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.